### PR TITLE
Always show Join button in current game rows

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -83,13 +83,8 @@ td.join-btn {
   text-align: right;
 }
 
-tr.game-list-row:hover button {
-  visibility: visible;
-}
-
 button.game-list-join {
   margin: 0;
-  visibility: hidden;
   display: table-cell;
   height: 23px;
   line-height: 0;


### PR DESCRIPTION
Extensive user-testing shows that many people fail to hover over the row (or are unable on mobile) and miss the Join button.